### PR TITLE
Added support for Symfony YAML library v4 and v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "amphp/amp": "^2",
         "amphp/socket": "^1.0",
         "amphp/uri": "^0.1",
-        "symfony/yaml": "^3.3"
+        "symfony/yaml": "^3.3|^4|^5"
     },
     "require-dev": {
         "amphp/phpunit-util": "^1",


### PR DESCRIPTION
Locking the YAML library to v3 prevents this library from being used in Symfony 4 or 5 projects. Despite the major version increments, these seem entirely backwards compatible because they're just incremented along with the Symfony framework itself (they do not follow Semver).